### PR TITLE
Obox Ninja Demo Updates

### DIFF
--- a/classes/sandbox.php
+++ b/classes/sandbox.php
@@ -547,7 +547,7 @@ class Ninja_Demo_Sandbox {
 					wp_get_referer()
 				)
 			);
-			return;
+			die;
 		}
 
 		if ( $login_role == 'administrator' ) {

--- a/classes/sandbox.php
+++ b/classes/sandbox.php
@@ -535,6 +535,7 @@ class Ninja_Demo_Sandbox {
 		// Create our user.
 		$user_id = wp_create_user( $user_name, $random_password, $user_email );
 
+		// Do not allow duplicate users, this may be the case if we have added a filter on the username or email
 		if( is_wp_error( $user_id ) ){
 			wp_redirect(
 				add_query_arg(

--- a/classes/sandbox.php
+++ b/classes/sandbox.php
@@ -540,13 +540,14 @@ class Ninja_Demo_Sandbox {
 				add_query_arg(
 					array(
 						'error' => 'true',
+						'errorcode' => urlencode( $user_id->get_error_code() ),
 						'errormsg' => urlencode( $user_id->get_error_message() ),
 						'updated' => false
 					),
 					wp_get_referer()
 				)
 			);
-			die;
+			return;
 		}
 
 		if ( $login_role == 'administrator' ) {
@@ -583,8 +584,9 @@ class Ninja_Demo_Sandbox {
 		if( stripos($target_subd, $source_site) !== false ) {
 				wp_redirect( add_query_arg(
 					array('error' => 'true',
-						  'errormsg' => urlencode( __( "The Source Site Name ($source_site) may not appear in the Target Site Domain ($target_subd) or data corruption will occur. You might need to edit the Source Site's Name in Settings > General, or double-check / change your field input values.", 'ns_cloner' ) ),
-						  'updated' => false),
+						'errorcode' => urlencode( $user_id->get_error_code() ),
+						'errormsg' => urlencode( __( "The Source Site Name ($source_site) may not appear in the Target Site Domain ($target_subd) or data corruption will occur. You might need to edit the Source Site's Name in Settings > General, or double-check / change your field input values.", 'ns_cloner' ) ),
+						'updated' => false),
 					wp_get_referer() ) );
 				die;
 		} else{

--- a/classes/sandbox.php
+++ b/classes/sandbox.php
@@ -86,7 +86,7 @@ class Ninja_Demo_Sandbox {
 	/**
 	 * Check to see if any of our blogs have been marked as "deleted."
 	 * If so, undelete them.
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0.7
 	 * @return void
@@ -98,7 +98,7 @@ class Ninja_Demo_Sandbox {
 	        FROM $wpdb->blogs
 	        WHERE deleted = '1'"
 	    );
-	    foreach ( $blogs as $blog ) {   	
+	    foreach ( $blogs as $blog ) {
 	    	if ( get_blog_option( $blog->blog_id, 'nd_sandbox' ) != 1 ) {
 	    		$wpdb->update( $wpdb->blogs, array( 'deleted' => '0' ) , array( 'blog_id' => $blog->blog_id ) );
 	    	}
@@ -127,7 +127,7 @@ class Ninja_Demo_Sandbox {
 	    		} else if ( $source_id == get_blog_option( $blog->blog_id, 'nd_source_id' ) ) {
 	    			$count++;
 	    		}
-	    		
+
 	    	}
 	    }
 		return $count;
@@ -135,7 +135,7 @@ class Ninja_Demo_Sandbox {
 
 	/**
 	 * Function to get our sandbox key (the random string associated with the sandbox)
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0.4
 	 * @return string $id
@@ -326,7 +326,7 @@ class Ninja_Demo_Sandbox {
 
 	/**
 	 * Add our purge action for execution
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0.9
 	 * @return void
@@ -354,7 +354,7 @@ class Ninja_Demo_Sandbox {
 	    $sites = array();
 	    $redirect = false;
 	    foreach ( $blogs as $blog ) {
-	    	
+
 	    	if ( get_blog_option( $blog->blog_id, 'nd_sandbox' ) == 1 ) {
 		   		// If we've been alive longer than the lifespan, delete the sandbox.
 		   		if ( apply_filters( 'nd_purge_sandbox', $this->has_expired( $blog->blog_id ), $blog->blog_id ) ) {
@@ -366,7 +366,7 @@ class Ninja_Demo_Sandbox {
 					$this->delete( $blog->blog_id );
 		   		}
 	    	}
-	    	
+
 		}
 
 		if ( $redirect ) {
@@ -377,7 +377,7 @@ class Ninja_Demo_Sandbox {
 
 	/**
 	 * Check to see if this sandbox has expired
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0
 	 * @return bool;
@@ -398,7 +398,7 @@ class Ninja_Demo_Sandbox {
 
 	/**
 	 * Check to see if a sandbox is alive
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0
 	 * @return bool
@@ -435,7 +435,7 @@ class Ninja_Demo_Sandbox {
 
 	/**
 	 * Update our sandbox active state when we load a page.
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0
 	 * @return void
@@ -448,7 +448,7 @@ class Ninja_Demo_Sandbox {
 
 	/**
 	 * Listen for the sandbox reset $_REQUEST data
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0
 	 * @return void
@@ -458,7 +458,7 @@ class Ninja_Demo_Sandbox {
 		// Bail if our $_POST value isn't set.
 		if ( ! isset ( $_GET['reset_sandbox'] ) || $_GET['reset_sandbox'] != 1 )
 			return false;
-		
+
 		// Bail if we don't have a nonce
 		if ( ! isset ( $_GET['ninja_demo_sandbox'] ) )
 			return false;
@@ -472,7 +472,7 @@ class Ninja_Demo_Sandbox {
 
 	/**
 	 * "Reset" a user's sandbox by removing the current one and creating a new one.
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0
 	 * @return void
@@ -514,7 +514,7 @@ class Ninja_Demo_Sandbox {
 
 		$target_site = get_blog_details( $source_id )->blogname;
 		if ( $target_site_name == '' ) {
-			$target_site_name = $this->generate_site_name();			
+			$target_site_name = $this->generate_site_name();
 		}
 
 		/**
@@ -524,13 +524,30 @@ class Ninja_Demo_Sandbox {
 		$login_role = isset ( $nd_settings['login_role'] ) ? $nd_settings['login_role'] : 'administrator';
 
 	    // Get our username.
-	    $user_name = $login_role . '-' . $target_site_name;
+	    $user_name = apply_filters( 'nd_user_name' , $login_role . '-' . $target_site_name );
+
 	    // Get our user email address.
-	    $user_email = $login_role . '@' . $target_site_name .'.com';
+	    $user_email = apply_filters( 'nd_user_email' , $login_role . '@' . $target_site_name .'.com' );
+
 	    // Generate a random password.
 	    $random_password = wp_generate_password( $length = 12, $include_standard_special_chars = false );
+
 		// Create our user.
 		$user_id = wp_create_user( $user_name, $random_password, $user_email );
+
+		if( is_wp_error( $user_id ) ){
+			wp_redirect(
+				add_query_arg(
+					array(
+						'error' => 'true',
+						'errormsg' => urlencode( $user_id->get_error_message() ),
+						'updated' => false
+					),
+					wp_get_referer()
+				)
+			);
+			die;
+		}
 
 		if ( $login_role == 'administrator' ) {
 			$owner_user_id = $user_id;
@@ -545,7 +562,7 @@ class Ninja_Demo_Sandbox {
 			$owner_user_id = wp_create_user( $user_name, $random_password, $user_email );
 			remove_user_from_blog( $owner_user_id, $source_id );
 		}
-		
+
 		// CREATE THE SITE
 
 		// Create site
@@ -619,7 +636,7 @@ class Ninja_Demo_Sandbox {
 			$replace_array['/sites/' . $source_id . '/'] = '/sites/' . $target_id . '/';
 			//reset the option_name = wp_#_user_roles row in the wp_#_options table back to the id of the target site
 			$replace_array[$wpdb->base_prefix . $source_id . '_user_roles'] = $wpdb->base_prefix . $target_id . '_user_roles';
-		}		
+		}
 
 		//replace
 		Ninja_Demo()->logs->dlog ( 'running replace on Target table prefix: ' . $target_pre . '<br />' );
@@ -628,7 +645,7 @@ class Ninja_Demo_Sandbox {
 		}
 
 		$this->run_replace( $target_pre, $replace_array );
-		
+
 		// COPY ALL MEDIA FILES
 		// get the right paths to use
 		// handle for uploads location when cloning root site
@@ -665,7 +682,7 @@ class Ninja_Demo_Sandbox {
 			$report .= 'To: <b>' . $dst_blogs_dir . '</b><br />';
 		}
 		// ---------------------------------------------------------------------------------------------------------------
-		
+
 
 		//Switch to our new blog.
 		switch_to_blog( $this->target_id );
@@ -687,17 +704,17 @@ class Ninja_Demo_Sandbox {
 	    // Store our user name and password.
 	    update_blog_option( $this->target_id, 'nd_user', $user_name );
 	    update_blog_option( $this->target_id, 'nd_password', $random_password );
-	
+
 		// Login our user.
 		add_user_to_blog( $this->target_id, $user_id, $login_role );
 		remove_user_from_blog( $user_id, $source_id );
 		wp_clear_auth_cookie();
 	    wp_set_auth_cookie( $user_id, true );
-	    wp_set_current_user( $user_id );	    	
-	    
+	    wp_set_current_user( $user_id );
+
 	    // Set our "last updated" time to the current time.
 	    $wpdb->update( $wpdb->blogs, array( 'last_updated' => current_time( 'mysql' ) ), array( 'blog_id' => $this->target_id ) );
-	    
+
 	    // Get a list of our active plugins.
 	    $plugins = get_option( 'active_plugins' );
 
@@ -707,7 +724,7 @@ class Ninja_Demo_Sandbox {
 					deactivate_plugins( $plugin );
 					activate_plugin( $plugin );
 				}
-		    }	    	
+		    }
 	    }
 
 
@@ -816,7 +833,7 @@ class Ninja_Demo_Sandbox {
 				$user = $nd_settings['auto_login'];
 				$role = $nd_settings['login_role'];
 				add_user_to_blog( $this->target_id, $user, $role );
-			}			
+			}
 		}
 	}
 
@@ -849,7 +866,7 @@ class Ninja_Demo_Sandbox {
 			}
 			$SQL = "SHOW TABLES WHERE `Tables_in_" . $this->db_name . "` IN('" . implode( "','", $table_names ). "')";
 		} else { //get list of source tables when cloning non-root
-			// MUST ESCAPE '_' characters otherwise they will be interpreted as wildcard 
+			// MUST ESCAPE '_' characters otherwise they will be interpreted as wildcard
 			// single chars in LIKE statement and can really hose up the database
 			$SQL = 'SHOW TABLES LIKE \'' . str_replace( '_', '\_', $source_prefix ) . '%\'';
 		}
@@ -868,7 +885,7 @@ class Ninja_Demo_Sandbox {
 						continue 2;
 					}
 				}
-				
+
 				$pos = strpos( $source_table, $source_prefix );
 				if ( $pos === 0 ) {
 				    $target_table = substr_replace( $source_table, $target_prefix, $pos, strlen( $source_prefix ) );
@@ -1060,7 +1077,7 @@ class Ninja_Demo_Sandbox {
 				$table_query_count = 0;
 				$table_query = '';
 			}
-			
+
 		} // while ($row = mysql_fetch_row($result))
 
 		if ( ! empty( $table_query ) ) {
@@ -1071,7 +1088,7 @@ class Ninja_Demo_Sandbox {
 
 	/**
 	 * Run our insert statement.
-	 * 
+	 *
 	 * @access private
 	 * @since 1.0.9
 	 * @return void
@@ -1112,7 +1129,7 @@ class Ninja_Demo_Sandbox {
 
 		if ( isset ( $tables_list[0] ) && ! empty ( $tables_list[0] ) ) {
 			foreach ( $tables_list as $table ) {
-				
+
 				$table = $table[0];
 
 				$count_tables_checked++;

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -74,7 +74,7 @@ class Ninja_Demo_Shortcodes {
 			ob_start();
 
 			?>
-			<a id="ninja-demo"></a>
+			<a id="ninjademo"></a>
 			<div class="nd-start-demo">
 				<?php
 				// Check to

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -74,12 +74,12 @@ class Ninja_Demo_Shortcodes {
 			ob_start();
 
 			?>
-			<a id="ninjademo"></a>
+			<a id="ninja-demo"></a>
 			<div class="nd-start-demo">
 				<?php
 				// Check to
 				if ( ! $ip_lockout ) { ?>
-					<form action="<?php echo the_permalink(); ?>#ninjademo" method="post" enctype="multipart/form-data" class="nd-start-demo-form">
+					<form action="<?php echo the_permalink(); ?>#ninja-demo" method="post" enctype="multipart/form-data" class="nd-start-demo-form">
 						<?php wp_nonce_field( 'ninja_demo_create_sandbox','ninja_demo_sandbox' ); ?>
 						<input name="nd_create_sandbox" type="hidden" value="1">
 						<input name="tid" type="hidden" value="<?php echo $tid; ?>">

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -49,7 +49,7 @@ class Ninja_Demo_Shortcodes {
 		} else {
 			$source_id = get_current_blog_id();
 		}
-		
+
 		$spam_q = $this->get_spam_question();
 		$spam_a = $this->get_spam_answer( $spam_q );
 		$tid = $this->set_transient( $spam_a );
@@ -57,21 +57,21 @@ class Ninja_Demo_Shortcodes {
 		$ip = $_SERVER['REMOTE_ADDR'];
 
 		Ninja_Demo()->ip->free_ip( $ip );
-		
+
 		// Get the number of tries we have left before we are locked out.
 		if ( isset ( $_SESSION['ninja_demo_failed'] ) ) {
 			$tries = 4 - $_SESSION['ninja_demo_failed'];
 		}
-		
+
 		if ( ! Ninja_Demo()->is_sandbox() )
 			$ip_lockout = Ninja_Demo()->ip->check_ip_lockout( $ip );
 
 		$output = '';
-		
+
 		if ( ! Ninja_Demo()->is_sandbox() ) {
-			
+
 			ob_start();
-			
+
 			?>
 			<a id="ninja-demo"></a>
 			<div class="nd-start-demo">
@@ -85,6 +85,15 @@ class Ninja_Demo_Shortcodes {
 						<input name="nd_create_sandbox" type="hidden" value="1">
 						<input name="tid" type="hidden" value="<?php echo $tid; ?>">
 						<input name="source_id" type="hidden" value="<?php echo $source_id; ?>">
+						<?php
+							if ( isset ( $_GET['errormsg'] ) ) {
+						?>
+							<div>
+								<?php echo $_GET['errormsg'];  ?>
+							</div>
+						<?php
+							}
+						?>
 						<?php
 						do_action( 'nd_before_anti_spam', $source_id );
 						?>
@@ -140,7 +149,7 @@ class Ninja_Demo_Shortcodes {
 						printf( __( 'You are unable to create a sandbox for %d minutes.', 'ninja-demo' ), $expires );
 					}
 
-					
+
 					if ( isset ( $_POST['tid'] ) )
 						delete_transient( $_POST['tid'] );
 					?></h4>
@@ -149,7 +158,7 @@ class Ninja_Demo_Shortcodes {
 				?>
 			</div>
 			<?php
-		
+
 			$output = ob_get_clean();
 		} else { // If we are in a sandbox, show either a logout or login button.
 			if ( is_user_logged_in() ) {
@@ -169,7 +178,7 @@ class Ninja_Demo_Shortcodes {
 
 	/**
 	 * Output our login/logut button
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0.9
 	 * @return void
@@ -191,7 +200,7 @@ class Ninja_Demo_Shortcodes {
 	/**
 	 * Listen for our create sandbox button.
 	 * If everything passes, call the Ninja_Demo()->sandbox->create() function.
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0
 	 * @return void
@@ -253,7 +262,7 @@ class Ninja_Demo_Shortcodes {
 
 	/**
 	 * Listen for our logout click
-	 * 
+	 *
 	 * @access public
 	 * @since 1.1.0
 	 * @return void
@@ -274,7 +283,7 @@ class Ninja_Demo_Shortcodes {
 
 	/**
 	 * Listen for our login click
-	 * 
+	 *
 	 * @access public
 	 * @since 1.1.0
 	 * @return void
@@ -354,7 +363,7 @@ class Ninja_Demo_Shortcodes {
 
 	/**
 	 * Output a button for resetting the demo
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0
 	 * @return string $output
@@ -368,7 +377,7 @@ class Ninja_Demo_Shortcodes {
 		?>
 		<form action="" method="post" enctype="multipart/form-data" class="nd-reset-demo-form">
 			<input type="hidden" name="reset_sandbox" value="1">
-			<?php wp_nonce_field( 'ninja_demo_reset_sandbox','ninja_demo_sandbox' ); ?> 
+			<?php wp_nonce_field( 'ninja_demo_reset_sandbox','ninja_demo_sandbox' ); ?>
 			<input type="submit" name="reset_sandbox_submit" value="<?php _e( 'Reset Sandbox Content', 'ninja-demo' ); ?>">
 		</form>
 		<?php
@@ -378,7 +387,7 @@ class Ninja_Demo_Shortcodes {
 
 	/**
 	 * is_sandbox shortcode
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0
 	 * @return string $content or bool(false)
@@ -393,7 +402,7 @@ class Ninja_Demo_Shortcodes {
 
 	/**
 	 * is_not_sandbox shortcode
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0
 	 * @return string $content or bool(false)
@@ -408,7 +417,7 @@ class Ninja_Demo_Shortcodes {
 
 	/**
 	 * is_sandbox_expired shortcode
-	 * 
+	 *
 	 * @access public
 	 * @since 1.0
 	 * @return string $content or bool(false)

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -374,7 +374,7 @@ class Ninja_Demo_Shortcodes {
 		if ( get_transient( $key ) !== false ) {
 			return $this->set_transient( $value );
 		} else {
-			set_transient( $key, $value, 900 ); //15 minutes
+			set_transient( $key, $value, apply_filters( 'nd_question_timeout', 300 ) );
 		}
 		return $key;
 	}

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -217,6 +217,8 @@ class Ninja_Demo_Shortcodes {
 	 */
 	public function create_listen() {
 
+		do_action( 'nd_create_listen' );
+
 		// Add any errors which have been passed back to us from the redirect
 		if ( isset ( $_GET['errormsg'] ) )
 			$this->add_error( ( isset( $_GET['errormsg'] ) ? $_GET['errorcode'] : 'error' ) , $_GET['errormsg'] );

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -79,7 +79,7 @@ class Ninja_Demo_Shortcodes {
 				<?php
 				// Check to
 				if ( ! $ip_lockout ) { ?>
-					<form action="<?php echo the_permalink(); ?>#ninja-demo" method="post" enctype="multipart/form-data" class="nd-start-demo-form">
+					<form action="<?php echo the_permalink(); ?>#ninjademo" method="post" enctype="multipart/form-data" class="nd-start-demo-form">
 						<?php wp_nonce_field( 'ninja_demo_create_sandbox','ninja_demo_sandbox' ); ?>
 						<input name="nd_create_sandbox" type="hidden" value="1">
 						<input name="tid" type="hidden" value="<?php echo $tid; ?>">

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -249,13 +249,13 @@ class Ninja_Demo_Shortcodes {
 
 		// Bail if we haven't sent an answer to the anti-spam question
 		if ( ! isset( $_POST['spam_a'] ) || ! isset ( $_POST['tid'] ) ) {
-			$this->add_error( 'no-spam-entry', __( 'Your demo has expired. Please try again', 'ninja-demo' ) );
+			$this->add_error( 'no-spam-entry', __( 'We are missing a humanity check entry.', 'ninja-demo' ) );
 			return false;
 		}
 
 		// Bail if we haven't sent an answer to the anti-spam question
 		if ( false === get_transient( $_POST['tid'] ) ) {
-			$this->add_error( 'expired', __( 'Your demo has expired. Please try again', 'ninja-demo' ) );
+			$this->add_error( 'expired', __( 'Your humanity check has expired. Please try again.', 'ninja-demo' ) );
 			return false;
 		}
 

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -216,6 +216,8 @@ class Ninja_Demo_Shortcodes {
 	 * @return void
 	 */
 	public function create_listen() {
+		
+		do_action( 'nd_create_listen' );
 
 		// Add any errors which have been passed back to us from the redirect
 		if ( isset ( $_GET['errormsg'] ) ) {

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -216,9 +216,9 @@ class Ninja_Demo_Shortcodes {
 	 * @return void
 	 */
 	public function create_listen() {
-		
-		// Allow Dev's to stop the process if their form handling fails
-		if( apply_filters( 'nd_create_listen', false ) ){
+
+		// Allow Dev's to stop the process if their form handling fails, default to passing true (valid), fail when false is returned
+		if( false == apply_filters( 'nd_create_listen', true ) ){
 			return false;
 		}
 

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -79,7 +79,7 @@ class Ninja_Demo_Shortcodes {
 				<?php
 				// Check to
 				if ( ! $ip_lockout ) { ?>
-					<form action="#ninja-demo" method="post" enctype="multipart/form-data" class="nd-start-demo-form">
+					<form action="<?php echo the_permalink(); ?>#ninja-demo" method="post" enctype="multipart/form-data" class="nd-start-demo-form">
 						<?php wp_nonce_field( 'ninja_demo_create_sandbox','ninja_demo_sandbox' ); ?>
 						<input name="nd_create_sandbox" type="hidden" value="1">
 						<input name="tid" type="hidden" value="<?php echo $tid; ?>">

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -14,6 +14,11 @@
  */
 
 class Ninja_Demo_Shortcodes {
+	
+	/*
+	 * Check for errors during sandbox creation
+	 */
+	private $error = false; // Check for errors in sandbox creation
 
 	/**
 	 * Get things started
@@ -91,7 +96,13 @@ class Ninja_Demo_Shortcodes {
 						<div>
 							<label class="nd-answer-field"><?php echo _e( 'What does ', 'ninja-demo' ) . $spam_q; ?><input type="text" name="spam_a"></label>
 							<?php
-							if ( isset ( $_POST['spam_a'] ) && $_POST['spam_a'] != get_transient( $_POST['tid'] ) ) {
+							if ( 'expired' == $this->error ) {
+							?>
+								<div>
+									<?php _e( 'Your demo has expired. Please try again', 'ninja-demo' ); ?>
+								</div>
+							<?php
+							} else if ( 'failed' == $this->error ) {
 							?>
 								<div>
 									<?php _e( 'Incorrect answer. Please try again.', 'ninja-demo' ); ?>
@@ -225,6 +236,12 @@ class Ninja_Demo_Shortcodes {
 		// Bail if we haven't sent an answer to the anti-spam question
 		if ( ! isset( $_POST['spam_a'] ) || ! isset ( $_POST['tid'] ) )
 			return false;
+		
+		// Bail if we haven't sent an answer to the anti-spam question
+		if ( false === get_transient( $_POST['tid'] ) ) {
+			$this->error = 'expired';
+			return false;
+		}
 
 		// Bail if our anti-spam answer isn't correct
 		if ( $_POST['spam_a'] != get_transient( $_POST['tid'] ) ) {
@@ -242,7 +259,8 @@ class Ninja_Demo_Shortcodes {
 			}
 			// Remove our transient answer
 			delete_transient( $_POST['tid'] );
-
+			
+			$this->error = 'failed';
 			return false;
 		}
 		// Remove our transient answer
@@ -347,7 +365,7 @@ class Ninja_Demo_Shortcodes {
 		if ( get_transient( $key ) !== false ) {
 			return $this->set_transient( $value );
 		} else {
-			set_transient( $key, $value, 300 );
+			set_transient( $key, $value, 900 ); //15 minutes
 		}
 		return $key;
 	}

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -217,11 +217,11 @@ class Ninja_Demo_Shortcodes {
 	 */
 	public function create_listen() {
 
-		do_action( 'nd_create_listen' );
-
 		// Add any errors which have been passed back to us from the redirect
-		if ( isset ( $_GET['errormsg'] ) )
+		if ( isset ( $_GET['errormsg'] ) ) {
 			$this->add_error( ( isset( $_GET['errormsg'] ) ? $_GET['errorcode'] : 'error' ) , $_GET['errormsg'] );
+			return false;
+		}
 
 		// Bail if the "prevent_clones" has been set to 1
 		if ( Ninja_Demo()->settings['prevent_clones'] == 1 )

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -217,7 +217,10 @@ class Ninja_Demo_Shortcodes {
 	 */
 	public function create_listen() {
 		
-		do_action( 'nd_create_listen' );
+		// Allow Dev's to stop the process if their form handling fails
+		if( apply_filters( 'nd_create_listen', false ) ){
+			return false;
+		}
 
 		// Add any errors which have been passed back to us from the redirect
 		if ( isset ( $_GET['errormsg'] ) ) {


### PR DESCRIPTION
While using Ninja Demo on try.layerswp.com we loved it but had some extra functionality that we wanted to add.

We also needed better error handling, so we added two functions which developers can use to add and display errors above the sign up form.

Main raft of changes:
- Addition of the `add_error()` and `output_errors()` functions to shortcodes.php, this allows developers to add custom errors to the form.
- Addition of the `apply_filters( 'nd_create_listen', true )` filter inside `sandbox->create_listen();` allows developers to pre-check parameters before `create_sandbox();` is fired and `return false;` if the form needs to fail and we need to add an error
- Addition of the `nd_user_name` filter allows developers to add custom usernames according to a name input (for example)
- Addition of the `nd_user_email` filter allows developers to add custom user email addresses according to an email input (for example).
- Below the `$user_name` and `$user_email` settings, we've added a check against the user database to avoid duplicates.
- Addition of the `nd_question_timeout` filter allows developers to extend the timeout checker.
