### PR TITLE
Fix $pagenow assignment operator in conditional

### DIFF
--- a/classes/restrictions.php
+++ b/classes/restrictions.php
@@ -249,7 +249,7 @@ class Ninja_Demo_Restrictions {
 					wp_die( __( apply_filters( 'nd_block_msg', 'You do not have sufficient permissions to access this page.' ), 'ninja-demo' ) );
 				}
 
-			} else if ( $pagenow == 'admin.php' || $pagenow == 'index.php' || $pagenow == 'options-general.php' || $pagenow = 'themes.php' ) {
+			} else if ( $pagenow == 'admin.php' || $pagenow == 'index.php' || $pagenow == 'options-general.php' || $pagenow == 'themes.php' ) {
 				$screen = get_current_screen();
 				if ( $screen->id == 'dashboard' ) {
 					$found = true;


### PR DESCRIPTION
This bug caused the global $pagenow variable to be set to 'themes.php' when the conditional was reached instead of comparing the value.

WordPress triggers `do_action( 'load-' $pagenow );` on many pages and the assignment operator resulted in unexpected behavior on certain pages (i.e. `/wp-admin/customize.php`).
