### PR TITLE
Causes a Headers Already Sent conflict

### DIFF
--- a/classes/sandbox.php
+++ b/classes/sandbox.php
@@ -900,7 +900,6 @@ class Ninja_Demo_Sandbox {
 					Ninja_Demo()->logs->dlog ( '-----------------------------------------------------------------------------------------------------------<br />' );
 					Ninja_Demo()->logs->dlog ( 'Cloning source table: <b>' . $source_table . '</b> (table #' . $num_tables . ') to Target table: <b>' . $target_table . '</b><br />' );
 					Ninja_Demo()->logs->dlog ( '-----------------------------------------------------------------------------------------------------------<br />' );
-					echo 'About to clone source table: <b>' . $source_table . '</b> (table #' . $num_tables . ') to Target table: <b>' . $target_table . '</b><br />';
 
 					$this->clone_table( $source_table, $target_table );
 					


### PR DESCRIPTION
This line causes a "Headers Already Sent" conflict with pluggable.php.

I can't think of a single reason that this would need to be output to the user activating the demo, so nuked it.
